### PR TITLE
Remove sleepless_squads dependency

### DIFF
--- a/bridge/esx/client.lua
+++ b/bridge/esx/client.lua
@@ -1,6 +1,6 @@
 local Groups = {}
 local Loaded = false
-local utils = require 'resources.[dev].sleepless_squads.moduless.utils'
+local utils = require 'imports.utils'
 local playerItems = utils.getItems()
 local ox_inv = GetResourceState('ox_inventory'):find('start')
 local ESX = exports.es_extended:getSharedObject()

--- a/bridge/qb/client.lua
+++ b/bridge/qb/client.lua
@@ -1,7 +1,7 @@
 local QBCore = exports['qb-core']:GetCoreObject()
 local Groups = {}
 local Player = {}
-local utils = require 'resources.[dev].sleepless_squads.moduless.utils'
+local utils = require 'imports.utils'
 local playerItems = utils.getItems()
 local ox_inv = GetResourceState('ox_inventory'):find('start')
 


### PR DESCRIPTION
It seems that the latest update has added an unintended dependency on the `sleepless_squads` resource. This pull request switches the QB and ESX bridge client files to import the built-in `utils.lua` file.