### PR TITLE
Alllow interaction specific non-active sprites

### DIFF
--- a/__types.lua
+++ b/__types.lua
@@ -26,7 +26,7 @@
 ---@field renderDistance number
 ---@field activeDistance number
 ---@field currentDistance number
----@field sprite? { dict: string, txt: string, color: vector4 }
+---@field sprite? { dict?: string, txt?: string, color?: vector4 }
 ---@field cooldown number
 ---@field DuiOptions {text: string, icon: string}
 ---@field getCoords fun(data: self): vector3

--- a/__types.lua
+++ b/__types.lua
@@ -26,6 +26,7 @@
 ---@field renderDistance number
 ---@field activeDistance number
 ---@field currentDistance number
+---@field sprite? { dict: string, txt: string, color: vector4 }
 ---@field cooldown number
 ---@field DuiOptions {text: string, icon: string}
 ---@field getCoords fun(data: self): vector3

--- a/classes/interaction.lua
+++ b/classes/interaction.lua
@@ -29,6 +29,13 @@ function Interaction:constructor(data)
     self.options = data.options
     self.isDestroyed = false
     self.DuiOptions = {}
+    self.sprite = data.sprite
+
+    if data.sprite ~= nil then
+        pcall(function()
+            lib.requestStreamedTextureDict(data.sprite.dict)
+        end)
+    end
 
     self.private = {
         lastActionTime = 0,
@@ -95,7 +102,18 @@ function Interaction:drawSprite()
         local scale = 0.025 * (distanceRatio)
         local dict = defaultIndicator.dict
         local txt = defaultIndicator.txt
-        DrawInteractiveSprite(dict, txt, 0, 0, scale, scale * ratio, 0.0, color.x, color.y, color.z, color.w)
+        local spriteColour = color
+
+        if self.sprite ~= nil then
+            dict = self.sprite.dict
+            txt = self.sprite.txt
+
+            if type(self.sprite.color) == 'vector4' then
+                spriteColour = self.sprite.color
+            end
+        end
+
+        DrawInteractiveSprite(dict, txt, 0, 0, scale, scale * ratio, 0.0, spriteColour.x, spriteColour.y, spriteColour.z, spriteColour.w)
     end
     ClearDrawOrigin()
 end
@@ -110,7 +128,11 @@ function Interaction:destroy()
     if self.globalType and ( self.entity or self.netId) then
         utils.wipeCacheForEntityKey(self.globalType, self.entity or self.netId)
     end
-    
+
+    if self.sprite ~= nil then
+        SetStreamedTextureDictAsNoLongerNeeded(self.sprite.dict)
+    end
+
     RemoveEventHandler(self.onStop)
     store.InteractionIds[self.id] = nil
 end

--- a/classes/interaction.lua
+++ b/classes/interaction.lua
@@ -1,7 +1,7 @@
 ---@diagnostic disable: undefined-field
 local config = require 'imports.config'
 local utils  = require 'imports.utils'
-local indicator = config.indicatorSprite
+local defaultIndicator = config.defaultIndicatorSprite
 local color = config.color
 local store = require 'imports.store'
 local dui = require 'imports.dui'
@@ -93,8 +93,8 @@ function Interaction:drawSprite()
         local distanceRatio = self:getDistance() / self.renderDistance
         distanceRatio = 0.5 + (0.25 * distanceRatio)
         local scale = 0.025 * (distanceRatio)
-        local dict = indicator.dict
-        local txt = indicator.txt
+        local dict = defaultIndicator.dict
+        local txt = defaultIndicator.txt
         DrawInteractiveSprite(dict, txt, 0, 0, scale, scale * ratio, 0.0, color.x, color.y, color.z, color.w)
     end
     ClearDrawOrigin()

--- a/classes/interaction.lua
+++ b/classes/interaction.lua
@@ -32,9 +32,7 @@ function Interaction:constructor(data)
     self.sprite = data.sprite
 
     if data?.sprite?.dict then
-        pcall(function()
-            lib.requestStreamedTextureDict(data.sprite.dict)
-        end)
+        pcall(lib.requestStreamedTextureDict, data.sprite.dict)
     end
 
     self.private = {

--- a/classes/interaction.lua
+++ b/classes/interaction.lua
@@ -31,7 +31,7 @@ function Interaction:constructor(data)
     self.DuiOptions = {}
     self.sprite = data.sprite
 
-    if data.sprite ~= nil then
+    if data?.sprite?.dict then
         pcall(function()
             lib.requestStreamedTextureDict(data.sprite.dict)
         end)
@@ -104,13 +104,13 @@ function Interaction:drawSprite()
         local txt = defaultIndicator.txt
         local spriteColour = color
 
-        if self.sprite ~= nil then
-            dict = self.sprite.dict
-            txt = self.sprite.txt
+        if self?.sprite?.dict and self?.sprite?.txt then
+            dict = self.sprite.dict --[[@as string]]
+            txt = self.sprite.txt --[[@as string]]
+        end
 
-            if type(self.sprite.color) == 'vector4' then
-                spriteColour = self.sprite.color
-            end
+        if self?.sprite?.color and type(self.sprite.color) == 'vector4' then
+            spriteColour = self.sprite.color --[[@as vector4]]
         end
 
         DrawInteractiveSprite(dict, txt, 0, 0, scale, scale * ratio, 0.0, spriteColour.x, spriteColour.y, spriteColour.z, spriteColour.w)
@@ -129,7 +129,7 @@ function Interaction:destroy()
         utils.wipeCacheForEntityKey(self.globalType, self.entity or self.netId)
     end
 
-    if self.sprite ~= nil then
+    if self?.sprite?.dict then
         SetStreamedTextureDictAsNoLongerNeeded(self.sprite.dict)
     end
 

--- a/client/main.lua
+++ b/client/main.lua
@@ -2,7 +2,7 @@ local utils = require 'imports.utils'
 local store = require 'imports.store'
 local dui = require 'imports.dui'
 local config = require 'imports.config'
-local indicator = config.indicatorSprite
+local indicator = config.defaultIndicatorSprite
 
 local drawLoopRunning = false
 local BuilderLoopRunning = false

--- a/imports/config.lua
+++ b/imports/config.lua
@@ -1,6 +1,6 @@
 ---@class InteractConfig
 ---@field color vector4 RGBA (R: 0-255, G: 0-255, B: 0-255, A: 0-255)
----@field indicatorSprite {dict: string, txt: string} non-active sprite dictionary/texture
+---@field defaultIndicatorSprite {dict: string, txt: string} non-active sprite dictionary/texture
 ---@field useShowKeyBind boolean true/false use a keybind to show and hide the interactions
 ---@field defaultShowKeyBind string default key mapping for the show interactions keybind
 ---@field showKeyBindBehavior "hold" | "toggle" sets the behavior of the show interactions key bind
@@ -8,7 +8,7 @@ local config = {}
 
 config.color = vec4(28, 126, 214, 200)
 
-config.indicatorSprite = { dict = 'shared', txt = 'emptydot_32' }
+config.defaultIndicatorSprite = { dict = 'shared', txt = 'emptydot_32' }
 
 config.useShowKeyBind = false
 


### PR DESCRIPTION
This adds a sprite parameter to the interaction options allowing per-interaction specifying of non-active sprites. The default indicator sprite will be used if no sprite is defined in the interaction options. This also allows for interaction sprites to override the default colour specified in the config (for the sprite only), mostly to allow for the use of the colour white to show the original colours of the streamed sprite. 

![image](https://github.com/Sleepless-Development/sleepless_interact/assets/5565402/eb724095-e017-42a9-a553-09cb9a78de22)