### PR TITLE
feat(addCoords): add js compat for vectors as tables

### DIFF
--- a/client/api.lua
+++ b/client/api.lua
@@ -162,6 +162,10 @@ function interact.addCoords(coords, options)
         coords = { coords }
     end
 
+    if coordsType == "table" and coords.x ~= nil then
+        coords = { vector3(coords.x, coords.y, coords.z) }
+    end
+
     local resource = GetInvokingResource()
     options = checkOptions(options)
     local ids = {}


### PR DESCRIPTION
currently when calling addCoords via export in any script using js/ts vectors come through as objects with x y z props on them instead of vector3 type. added logic to check if table is a vector3 shape interface before reshaping.