### PR TITLE
(Fix) Initialize store.peds if it doesn't exist.

### DIFF
--- a/client/api.lua
+++ b/client/api.lua
@@ -248,6 +248,7 @@ end
 --- Adds options globally for all peds.
 ---@param options Option | Option[] A single option or array of options.
 function interact.addGlobalPed(options)
+    store.peds = store.peds or {}
     addOptions(store.peds, options, GetInvokingResource(), store.bones.peds, store.offsets.peds)
 end
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/ac920ea9-fa98-4f63-8c62-0b131ff4138d)

Fix store.peds being nil when attempting to add a target after a resource stop when using interact.addGlobalPed. Didn't quite understand the point of setting it to nil so I didn't mess with it on "onClientResourceStop".