### PR TITLE
feat(api): support arrays for offset/coords

### DIFF
--- a/client/api.lua
+++ b/client/api.lua
@@ -94,8 +94,12 @@ local function addOptions(target, options, resource, bonesTarget, offsetsTarget)
             local offset = option[offsetKey]
             local offsetType = type(offset)
 
-            if offsetType == 'table' and offset.x and offset.y and offset.z then
-                offset = vec3(offset.x, offset.y, offset.z)
+            if offsetType == 'table' then
+                if table.type(offset) == 'array' and #offset == 3 then
+                    offset = vec3(offset[1], offset[2], offset[3])
+                elseif offset.x and offset.y and offset.z then
+                    offset = vec3(offset.x, offset.y, offset.z)
+                end
             end
 
             if offsetType ~= 'table' and offsetType ~= 'vector3' then
@@ -184,8 +188,12 @@ function interact.addCoords(coords, options)
         typeError('coords', 'vector3 or vector3[]', coordsType)
     end
 
-    if coordsType == "table" and coords.x and coords.y and coords.z then
-        coords = { vector3(coords.x, coords.y, coords.z) }
+    if coordsType == "table" then
+        if table.type(coords) == 'array' and type(coords[1]) ~= 'vector3' and #coords == 3 then
+            coords = { vector3(coords[1], coords[2], coords[3]) }
+        elseif coords.x and coords.y and coords.z then
+            coords = { vector3(coords.x, coords.y, coords.z) }
+        end
     end
 
     if coordsType ~= "table" then


### PR DESCRIPTION
Currently when doing typescript its quite annoying having to unpack an vector like

```
  offset: { x: OFFSET_COORDS.x, y: OFFSET_COORDS.y, z: OFFSET_COORDS.z },
```

Where with this I can just do

```
offset: OFFSET_COORDS.toArray(),
```

Not only more practicle but also a whole lot easier to read.

Note that this code is actually untested, so just be weary/do quick tests before merging.

Also sidenote for adding coords here
```
    if coordsType == "table" then
        if table.type(coords) == 'array' and type(coords[1]) ~= 'vector3' and #coords == 3 then
            coords = { vector3(coords[1], coords[2], coords[3]) }
        elseif coords.x and coords.y and coords.z then
            coords = { vector3(coords.x, coords.y, coords.z) }
        end
    end
```

It might be nice to also support arrays of {x=x, y=y, z=z} tables and arrays of number arrays at a later stage for better typescript support.