### PR TITLE
Apply maxInteractDistance to nearby entity scans (#36)

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -403,10 +403,10 @@ local function checkNearbyEntities(coords)
         end
     end
 
-    processEntities(getNearbyObjects(coords, 10.0), 'objects')
-    processEntities(getNearbyVehicles(coords, 10.0, true), 'vehicles')
-    processEntities(getNearbyPlayers(coords, 10.0, false), 'players')
-    processEntities(getNearbyPeds(coords, 10.0), 'peds')
+    processEntities(getNearbyObjects(coords, config.nearbyObjectsDistance or config.maxInteractDistance), 'objects')
+    processEntities(getNearbyVehicles(coords, config.nearbyVehiclesDistance or config.maxInteractDistance, true), 'vehicles')
+    processEntities(getNearbyPlayers(coords, config.nearbyPlayersDistance or config.maxInteractDistance, false), 'players')
+    processEntities(getNearbyPeds(coords, config.nearbyPedsDistance or config.maxInteractDistance), 'peds')
 
     return valid
 end

--- a/client/modules/config.lua
+++ b/client/modules/config.lua
@@ -4,6 +4,14 @@ local config = {}
 -- recommend keeping this pretty low for optimization
 config.maxInteractDistance = 5.0
 
+-- Maximum distance used when scanning for nearby entities of each pool.
+-- Defaults to config.maxInteractDistance when left nil. Set a number to override
+-- the scan radius per pool independently of the render distance.
+config.nearbyObjectsDistance = nil
+config.nearbyVehiclesDistance = nil
+config.nearbyPlayersDistance = nil
+config.nearbyPedsDistance = nil
+
 -- {0-255, 0-255, 0-255, 0-255}
 config.themeColor = { 28, 100, 184, 200 } --- r, g, b, a
 


### PR DESCRIPTION
## Summary
- Replaces the hardcoded `10.0` radius in `getNearbyObjects/Vehicles/Players/Peds` with `config.maxInteractDistance`, so the existing distance config actually applies to entity scanning.
- Adds optional per-pool overrides (`nearbyObjectsDistance`, `nearbyVehiclesDistance`, `nearbyPlayersDistance`, `nearbyPedsDistance`) for users who want to decouple scan radius from the render distance, as suggested in the issue.

Closes #36.

## Test plan
- [ ] Default config: interactions on objects/vehicles/players/peds resolve within `maxInteractDistance`.
- [ ] Lower `maxInteractDistance` (e.g. `3.0`): entities beyond that range no longer enter the nearby pool.
- [ ] Set `config.nearbyObjectsDistance = 15.0` while keeping `maxInteractDistance = 5.0`: object interactions scan at 15m, render still gated by 5m.